### PR TITLE
Add support for server side Flask-SQLAlchemy backed sessions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,6 +119,7 @@ A list of configuration keys also understood by the extension:
                               - **memcached**: MemcachedSessionInterface
                               - **filesystem**: FileSystemSessionInterface
                               - **mongodb**: MongoDBSessionInterface
+                              - **sqlalchemy**: SqlAlchemySessionInterface
 ``SESSION_KEY_PREFIX``        A prefix that is added before all session keys.
                               This makes it possible to use the same backend
                               storage server for different apps, default 
@@ -140,6 +141,9 @@ A list of configuration keys also understood by the extension:
                               "flask_session"
 ``SESSION_MONGODB_COLLECT``   The MongoDB collection you want to use, default
                               "sessions"
+``SESSION_SQLALCHEMY``        A ``flask.ext.sqlalchemy.SQLAlchemy`` instance
+                              whose database connection URI is configured
+                              using the ``SQLALCHEMY_DATABASE_URI`` parameter
 ============================= ==============================================
 
 Basically you only need to configure ``SESSION_TYPE``.
@@ -197,6 +201,15 @@ Uses the MongoDB as a session backend. (`pymongo`_ required)
 .. _memcache: https://github.com/linsomniac/python-memcached
 .. _pymongo: http://api.mongodb.org/python/current/index.html
 
+:class:`SqlAlchemySessionInterface`
+```````````````````````````````````
+
+Uses SQLAlchemy as a session backend. (`Flask-SQLAlchemy`_ required)
+
+- SESSION_SQLALCHEMY
+
+.. _Flask-SQLAlchemy: https://pythonhosted.org/Flask-SQLAlchemy/
+
 API
 ---
 
@@ -215,5 +228,6 @@ API
 .. autoclass:: MemcachedSessionInterface
 .. autoclass:: FileSystemSessionInterface
 .. autoclass:: MongoDBSessionInterface
+.. autoclass:: SqlAlchemySessionInterface
 
 .. include:: ../CHANGES

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -144,6 +144,8 @@ A list of configuration keys also understood by the extension:
 ``SESSION_SQLALCHEMY``        A ``flask.ext.sqlalchemy.SQLAlchemy`` instance
                               whose database connection URI is configured
                               using the ``SQLALCHEMY_DATABASE_URI`` parameter
+``SESSION_SQLALCHEMY_TABLE``  The name of the SQL table you want to use,
+                              default "sessions"
 ============================= ==============================================
 
 Basically you only need to configure ``SESSION_TYPE``.
@@ -207,6 +209,7 @@ Uses the MongoDB as a session backend. (`pymongo`_ required)
 Uses SQLAlchemy as a session backend. (`Flask-SQLAlchemy`_ required)
 
 - SESSION_SQLALCHEMY
+- SESSION_SQLALCHEMY_TABLE
 
 .. _Flask-SQLAlchemy: https://pythonhosted.org/Flask-SQLAlchemy/
 

--- a/flask_session/__init__.py
+++ b/flask_session/__init__.py
@@ -12,7 +12,7 @@ import os
 
 from .sessions import NullSessionInterface, RedisSessionInterface, \
      MemcachedSessionInterface, FileSystemSessionInterface, \
-     MongoDBSessionInterface
+     MongoDBSessionInterface, SqlAlchemySessionInterface
 
 
 class Session(object):
@@ -70,6 +70,7 @@ class Session(object):
         config.setdefault('SESSION_MONGODB', None)
         config.setdefault('SESSION_MONGODB_DB', 'flask_session')
         config.setdefault('SESSION_MONGODB_COLLECT', 'sessions')
+        config.setdefault('SESSION_SQLALCHEMY', None)
 
         if config['SESSION_TYPE'] == 'redis':
             session_interface = RedisSessionInterface(config['SESSION_REDIS'],
@@ -85,6 +86,10 @@ class Session(object):
             session_interface = MongoDBSessionInterface(
               config['SESSION_MONGODB'], config['SESSION_MONGODB_DB'],
               config['SESSION_MONGODB_COLLECT'], config['SESSION_KEY_PREFIX'])
+        elif config['SESSION_TYPE'] == 'sqlalchemy':
+            session_interface = SqlAlchemySessionInterface(
+                app,
+                config['SESSION_SQLALCHEMY'], config['SESSION_KEY_PREFIX'])
         else:
             session_interface = NullSessionInterface()
         

--- a/flask_session/__init__.py
+++ b/flask_session/__init__.py
@@ -71,6 +71,7 @@ class Session(object):
         config.setdefault('SESSION_MONGODB_DB', 'flask_session')
         config.setdefault('SESSION_MONGODB_COLLECT', 'sessions')
         config.setdefault('SESSION_SQLALCHEMY', None)
+        app.config.setdefault('SESSION_SQLALCHEMY_TABLE', 'sessions')
 
         if config['SESSION_TYPE'] == 'redis':
             session_interface = RedisSessionInterface(config['SESSION_REDIS'],

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -382,7 +382,9 @@ class SqlAlchemySessionInterface(SessionInterface):
         self.db = db
         self.key_prefix = key_prefix
 
-        class Sessions(self.db.Model):
+        class Session(self.db.Model):
+            __tablename__ = 'sessions'
+
             id = self.db.Column(self.db.Integer, primary_key=True)
             session_id = self.db.Column(self.db.String(256), unique=True)
             data = self.db.Column(self.db.Text)
@@ -397,7 +399,7 @@ class SqlAlchemySessionInterface(SessionInterface):
                 return '<Session data %s>' % self.data
 
         self.db.create_all()
-        self.sql_session_model = Sessions
+        self.sql_session_model = Session
 
     def _generate_sid(self):
         return str(uuid4())

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -383,7 +383,7 @@ class SqlAlchemySessionInterface(SessionInterface):
         self.key_prefix = key_prefix
 
         class Session(self.db.Model):
-            __tablename__ = 'sessions'
+            __tablename__ = app.config['SESSION_SQLALCHEMY_TABLE']
 
             id = self.db.Column(self.db.Integer, primary_key=True)
             session_id = self.db.Column(self.db.String(256), unique=True)

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -48,6 +48,10 @@ class MongoDBSession(ServerSideSession):
     pass
 
 
+class SqlAlchemySession(ServerSideSession):
+    pass
+
+
 class NullSessionInterface(SessionInterface):
     """Used to open a :class:`flask.sessions.NullSession` instance.
     """
@@ -357,4 +361,104 @@ class MongoDBSessionInterface(SessionInterface):
                            'expiration': expires}, True)
         response.set_cookie(app.session_cookie_name, session.sid,
                             expires=expires, httponly=httponly,
+                            domain=domain, path=path, secure=secure)
+
+
+class SqlAlchemySessionInterface(SessionInterface):
+    """Uses the Flask-SQLAlchemy from a flask app as a session backend.
+
+    :param app: A Flask app instance.
+    :param db: A Flask-SQLAlchemy instance.
+    :param key_prefix: A prefix that is added to all store keys.
+    """
+
+    serializer = pickle
+    session_class = SqlAlchemySession
+
+    def __init__(self, app, db, key_prefix):
+        if db is None:
+            from flask.ext.sqlalchemy import SQLAlchemy
+            db = SQLAlchemy(app)
+        self.db = db
+        self.key_prefix = key_prefix
+
+        class Sessions(self.db.Model):
+            id = self.db.Column(self.db.Integer, primary_key=True)
+            session_id = self.db.Column(self.db.String(256), unique=True)
+            data = self.db.Column(self.db.Text)
+            expiry = self.db.Column(self.db.DateTime)
+
+            def __init__(self, session_id, data, expiry):
+                self.session_id = session_id
+                self.data = data
+                self.expiry = expiry
+
+            def __repr__(self):
+                return '<Session data %s>' % self.data
+
+        self.db.create_all()
+        self.sql_session_model = Sessions
+
+    def _generate_sid(self):
+        return str(uuid4())
+
+    def open_session(self, app, request):
+        sid = request.cookies.get(app.session_cookie_name)
+        if sid:
+            session_id = self.key_prefix + sid
+            saved_session = self.sql_session_model.query.filter_by(
+                session_id=session_id).first()
+            if saved_session:
+                if saved_session.expiry > datetime.utcnow():
+                    try:
+                        val = saved_session.data
+                        data = self.serializer.loads(str(val))
+
+                        return self.session_class(data, sid=sid)
+
+                    except Exception as e:
+                        print "some exception %s" % e.message
+                        self.db.delete(saved_session)
+                        self.db.session.commit()
+                else:
+                    # saved session expired. Delete it
+                    self.db.delete(saved_session)
+                    self.db.session.commit()
+
+        sid = self._generate_sid()
+        return self.session_class(sid=sid)
+
+    def save_session(self, app, session, response):
+        domain = self.get_cookie_domain(app)
+        path = self.get_cookie_path(app)
+
+        if not session:
+            response.delete_cookie(app.session_cookie_name, domain=domain)
+            return
+
+        session_id = self.key_prefix + session.sid
+        httponly = self.get_cookie_httponly(app)
+        secure = self.get_cookie_secure(app)
+        new_expiry = self.get_expiration_time(app, session)
+        val = self.serializer.dumps(dict(session))
+
+        saved_session = self.sql_session_model.query.filter_by(
+            session_id=session_id).first()
+
+        if saved_session:
+            if session.modified:
+                # update the saved session only if session
+                # was modified since last save
+                saved_session.data = val
+                saved_session.expiry = new_expiry
+                self.db.session.commit()
+        else:
+            # create new session object
+            new_session = self.sql_session_model(session_id, val, new_expiry)
+            self.db.session.add(new_session)
+            self.db.session.commit()
+
+        session.modified = False
+        response.set_cookie(app.session_cookie_name, session.sid,
+                            expires=new_expiry, httponly=httponly,
                             domain=domain, path=path, secure=secure)

--- a/test_session.py
+++ b/test_session.py
@@ -93,8 +93,6 @@ class FlaskSessionTestCase(unittest.TestCase):
         app = flask.Flask(__name__)
         app.config['SESSION_TYPE'] = 'sqlalchemy'
         app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///'
-        #app.config['SQLALCHEMY_ECHO'] = False
-        #app.config['SECRET_KEY'] = os.urandom(24)
         Session(app)
         @app.route('/set', methods=['POST'])
         def set():

--- a/test_session.py
+++ b/test_session.py
@@ -89,6 +89,25 @@ class FlaskSessionTestCase(unittest.TestCase):
         self.assertEqual(c.post('/set', data={'value': '42'}).data, b'value set')
         self.assertEqual(c.get('/get').data, b'42')
 
+    def test_flasksqlalchemy_session(self):
+        app = flask.Flask(__name__)
+        app.config['SESSION_TYPE'] = 'sqlalchemy'
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///'
+        #app.config['SQLALCHEMY_ECHO'] = False
+        #app.config['SECRET_KEY'] = os.urandom(24)
+        Session(app)
+        @app.route('/set', methods=['POST'])
+        def set():
+            flask.session['value'] = flask.request.form['value']
+            return 'value set'
+        @app.route('/get')
+        def get():
+            return flask.session['value']
+
+        c = app.test_client()
+        self.assertEqual(c.post('/set', data={'value': '42'}).data, b'value '
+                                                                    b'set')
+        self.assertEqual(c.get('/get').data, b'42')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The current Flask-Session implementation provides support for NoSQL options, such as MongoDB and Redis, but no support for SQL options, such as Oracle, MySQL, or SQLServer, etc.

Adding support for Flask-SQLAlchemy backed sessions adds support for all SQL options that Flask-SQLAlchemy supports. Here is a simple example of using Flask-SQLAlchemy with Flask-Session.

```python
import os
from flask import Flask
from flask.ext.session import Session
from flask.ext.sqlalchemy import SQLAlchemy

SECRET_KEY = os.urandom(24)
SESSION_TYPE = 'sqlalchemy'
SQLALCHEMY_DATABASE_URI = 'sqlite:////tmp/database.db'

app = Flask(__name__)
app.config.from_object(__name__)
db = SQLAlchemy(app)
app.config['SESSION_SQLALCHEMY'] = db
Session(app)
```
Simply specify `SESSION_TYPE = 'sqlalchemy'` and set `SESSION_SQLALCHEMY` to an instance of Flask-SQLAlchemy. Instantiate the `Session` with the `app` set up to use Flask-SQLAlchemy.

Special thanks to Viswa Vutharkar for his effort in implementing the new Flask-SQLAlchemy backed session implementation. If fills a gap in Flask-Session by adding support for SQL datastores.