### PR TITLE
fixed 'Specified key was too long; max key length is 767 bytes' with InnoDB/UTF-8

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -475,7 +475,7 @@ class SqlAlchemySessionInterface(SessionInterface):
             __tablename__ = table
 
             id = self.db.Column(self.db.Integer, primary_key=True)
-            session_id = self.db.Column(self.db.String(256), unique=True)
+            session_id = self.db.Column(self.db.String(255), unique=True)
             data = self.db.Column(self.db.Text)
             expiry = self.db.Column(self.db.DateTime)
 


### PR DESCRIPTION
When default table settings for the DB are InnoDB+UTF-8, VARCHAR(256) fields require 768 bytes for the UNIQE index key which is above the MySQL limit of 767 bytes. Lowering session_id field length to 255 chars is enough to fix this.

More details on the index limits in MySQL can be found here: http://stackoverflow.com/questions/1814532/1071-specified-key-was-too-long-max-key-length-is-767-bytes/16820166#16820166
