### PR TITLE
Do not set cookie if not required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+.idea

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -418,6 +418,8 @@ class MongoDBSessionInterface(SessionInterface):
             # Delete expired session
             self.store.remove({'id': store_id})
             document = None
+        if not document:
+            sid = self._generate_sid()
         if document is not None:
             try:
                 val = document['val']

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -139,6 +139,8 @@ class RedisSessionInterface(SessionInterface):
         return self.session_class(sid=sid, permanent=self.permanent)
 
     def save_session(self, app, session, response):
+        if not self.should_set_cookie(app, session):
+            return
         domain = self.get_cookie_domain(app)
         path = self.get_cookie_path(app)
         if not session:
@@ -260,6 +262,8 @@ class MemcachedSessionInterface(SessionInterface):
         return self.session_class(sid=sid, permanent=self.permanent)
 
     def save_session(self, app, session, response):
+        if not self.should_set_cookie(app, session):
+            return
         domain = self.get_cookie_domain(app)
         path = self.get_cookie_path(app)
         full_session_key = self.key_prefix + session.sid
@@ -338,6 +342,8 @@ class FileSystemSessionInterface(SessionInterface):
         return self.session_class(sid=sid, permanent=self.permanent)
 
     def save_session(self, app, session, response):
+        if not self.should_set_cookie(app, session):
+            return
         domain = self.get_cookie_domain(app)
         path = self.get_cookie_path(app)
         if not session:
@@ -422,6 +428,8 @@ class MongoDBSessionInterface(SessionInterface):
         return self.session_class(sid=sid, permanent=self.permanent)
 
     def save_session(self, app, session, response):
+        if not self.should_set_cookie(app, session):
+            return
         domain = self.get_cookie_domain(app)
         path = self.get_cookie_path(app)
         store_id = self.key_prefix + session.sid


### PR DESCRIPTION
As currently implemented, flask session will add the set-cookie header to every request including static files, etc. this prevents most standard caching setups.  We should call `self.should_set_cookie()` to determine if the set-cookie header should be included. 


With flask default config, this doesn't actually modify the set-cookie header behavior. But, with this change, and by setting  `SESSION_REFRESH_EACH_REQUEST` to False in the flask app config, the set-cookie header will only be included when the `session.modified` is True.  This attribute is set anytime one modifies the session, but can also be set manually in specific flask views if needed to update session timeouts. 
 
