### PR TITLE
Fix wekzeug 1.0 compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git@github.com:mitsuhiko/flask-sphinx-themes.git
+	url = git@github.com:pallets/pallets-sphinx-themes.git

--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -310,7 +310,7 @@ class FileSystemSessionInterface(SessionInterface):
 
     def __init__(self, cache_dir, threshold, mode, key_prefix,
                  use_signer=False, permanent=True):
-        from werkzeug.contrib.cache import FileSystemCache
+        from cachelib.file import FileSystemCache
         self.cache = FileSystemCache(cache_dir, threshold=threshold, mode=mode)
         self.key_prefix = key_prefix
         self.use_signer = use_signer

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 Flask-Session
 -------------
 
-Flask-Session is an extension for Flask that adds support for 
+Flask-Session is an extension for Flask that adds support for
 Server-side Session to your application.
 
 Links
@@ -29,7 +29,8 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'Flask>=0.8'
+        'Flask>=0.8',
+        'cachelib'
     ],
     test_suite='test_session',
     classifiers=[


### PR DESCRIPTION
`werkzeug.contrib.cache` was moved to [https://github.com/pallets/cachelib](pallets/cachelib) since version 1.0