### PR TITLE
Switch from cachelib to flask_caching

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -291,7 +291,7 @@ class MemcachedSessionInterface(SessionInterface):
 
 
 class FileSystemSessionInterface(SessionInterface):
-    """Uses the :class:`cachelib.file.FileSystemCache` as a session backend.
+    """Uses the :class:`flask_caching.backends.filesystem.FileSystemCache` as a session backend.
 
     .. versionadded:: 0.2
         The `use_signer` parameter was added.
@@ -309,7 +309,7 @@ class FileSystemSessionInterface(SessionInterface):
 
     def __init__(self, cache_dir, threshold, mode, key_prefix,
                  use_signer=False, permanent=True):
-        from cachelib.file import FileSystemCache
+        from flask_caching.backends.filesystem import FileSystemCache
         self.cache = FileSystemCache(cache_dir, threshold=threshold, mode=mode)
         self.key_prefix = key_prefix
         self.use_signer = use_signer

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     platforms='any',
     install_requires=[
         'Flask>=0.8',
-        'cachelib'
+        'flask-caching>=1.7,<2',  # It drops Python 2.7 support since 1.8
     ],
     test_suite='test_session',
     classifiers=[


### PR DESCRIPTION
The recent 0.3.2 release seems unreliable. People reported issue #119 the next day.

I received similar report from a repo that I'm maintaining, and one suggestion led to a solution. This PR backport [that solution from my fork](https://github.com/rayluo/flask-session/pull/3/files). It will probably fix #119.