### PR TITLE
Use samesite cookie attribute from Flask app configuration

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -161,6 +161,7 @@ class RedisSessionInterface(SessionInterface):
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
         expires = self.get_expiration_time(app, session)
+        samesite = self.get_cookie_samesite(app)
         val = self.serializer.dumps(dict(session))
         self.redis.setex(name=self.key_prefix + session.sid, value=val,
                          time=total_seconds(app.permanent_session_lifetime))
@@ -170,7 +171,8 @@ class RedisSessionInterface(SessionInterface):
             session_id = session.sid
         response.set_cookie(app.session_cookie_name, session_id,
                             expires=expires, httponly=httponly,
-                            domain=domain, path=path, secure=secure)
+                            domain=domain, path=path, secure=secure,
+                            samesite=samesite)
 
 
 class MemcachedSessionInterface(SessionInterface):
@@ -275,6 +277,8 @@ class MemcachedSessionInterface(SessionInterface):
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
         expires = self.get_expiration_time(app, session)
+        samesite = self.get_cookie_samesite(app)
+
         if not PY2:
             val = self.serializer.dumps(dict(session), 0)
         else:
@@ -287,7 +291,8 @@ class MemcachedSessionInterface(SessionInterface):
             session_id = session.sid
         response.set_cookie(app.session_cookie_name, session_id,
                             expires=expires, httponly=httponly,
-                            domain=domain, path=path, secure=secure)
+                            domain=domain, path=path, secure=secure,
+                            samesite=samesite)
 
 
 class FileSystemSessionInterface(SessionInterface):
@@ -349,6 +354,8 @@ class FileSystemSessionInterface(SessionInterface):
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
         expires = self.get_expiration_time(app, session)
+        samesite = self.get_cookie_samesite(app)
+
         data = dict(session)
         self.cache.set(self.key_prefix + session.sid, data,
                        total_seconds(app.permanent_session_lifetime))
@@ -358,7 +365,8 @@ class FileSystemSessionInterface(SessionInterface):
             session_id = session.sid
         response.set_cookie(app.session_cookie_name, session_id,
                             expires=expires, httponly=httponly,
-                            domain=domain, path=path, secure=secure)
+                            domain=domain, path=path, secure=secure,
+                            samesite=samesite)
 
 
 class MongoDBSessionInterface(SessionInterface):
@@ -434,6 +442,7 @@ class MongoDBSessionInterface(SessionInterface):
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
         expires = self.get_expiration_time(app, session)
+        samesite = self.get_cookie_samesite(app)
         val = self.serializer.dumps(dict(session))
         self.store.update({'id': store_id},
                           {'id': store_id,
@@ -445,7 +454,8 @@ class MongoDBSessionInterface(SessionInterface):
             session_id = session.sid
         response.set_cookie(app.session_cookie_name, session_id,
                             expires=expires, httponly=httponly,
-                            domain=domain, path=path, secure=secure)
+                            domain=domain, path=path, secure=secure,
+                            samesite=samesite)
 
 
 class SqlAlchemySessionInterface(SessionInterface):
@@ -544,6 +554,7 @@ class SqlAlchemySessionInterface(SessionInterface):
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
         expires = self.get_expiration_time(app, session)
+        samesite = self.get_cookie_samesite(app)
         val = self.serializer.dumps(dict(session))
         if saved_session:
             saved_session.data = val
@@ -559,4 +570,5 @@ class SqlAlchemySessionInterface(SessionInterface):
             session_id = session.sid
         response.set_cookie(app.session_cookie_name, session_id,
                             expires=expires, httponly=httponly,
-                            domain=domain, path=path, secure=secure)
+                            domain=domain, path=path, secure=secure,
+                            samesite=samesite)


### PR DESCRIPTION
Added support for samesite cookie attribute, please merge it. Modified `save_session()` for all *SessionInterface:

```python
    def save_session(self, app, session, response):
        ...
        samesite = self.get_cookie_samesite(app)
        ...
        response.set_cookie(app.session_cookie_name, session_id,
                            expires=expires, httponly=httponly,
                            domain=domain, path=path, secure=secure,
                            samesite=samesite)
```
There is older pull request ( #116 ), I did not noticed it initially. But my request is for currenct version of Flask-Session, and fixes all *SessionInterface classes.

Until Flask-Session will support samesite (if you need working samesite right now), there is quick-n-dirty workaround to install my fork:
```
pip install git+https://github.com/yaroslaff/flask-session.git@samesite
```
