### PR TITLE
Flask-session 0.4.1

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,35 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: CI/CD
+
+on:
+  push:
+  pull_request:
+    branches: [ dev ]
+
+    # This guards against unknown PR until a community member vet it and label it.
+    types: [ labeled ]
+
+jobs:
+  cd:
+    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags') || github.ref == 'refs/heads/master')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+    - name: Build a package for release
+      run: |
+        python -m pip install build --user
+        python -m build --sdist --wheel --outdir dist/ .
+    - name: Publish to TestPyPI
+      run: echo "Last time I tried, I do not have permission to release it on Test PyPI"
+    - name: Publish to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/flask_session/__init__.py
+++ b/flask_session/__init__.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,18 @@ Links
   <https://github.com/fengsp/flask-session/zipball/master#egg=Flask-dev>`_
 
 """
+import re, io
 from setuptools import setup
 
+# setup.py shall not import main package
+__version__ = re.search(
+    r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]',  # It excludes inline comment too
+    io.open('flask_session/__init__.py', encoding='utf_8_sig').read()
+    ).group(1)
 
 setup(
     name='Flask-Session',
-    version='0.4.0',
+    version=__version__,
     url='https://github.com/fengsp/flask-session',
     license='BSD',
     author='Shipeng Feng',
@@ -29,7 +35,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'Flask>=0.8',
+        'Flask>=0.8,<2.3',  # Flask 2.3 removed app.session_cookie_name
         'cachelib'
     ],
     test_suite='test_session',


### PR DESCRIPTION
@fengsp , this is a patch that I mentioned to you offline. And it [has been shipped to PyPI](https://pypi.org/project/Flask-Session/#history). It would be great if you can merge it in, as-is.

The tangible change to the downstream developers is that this patch version temporarily pins to Flask<2.3. This is of course not a long term solution. Later we will merge in the other existing PR which will work on Flask 2.2+, and then we will ship it as Flask-session 0.5.0.

The other file that I introduced in this PR is a Github action that will make the subsequent release much easier. I did that all the time on [projects that I own](https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/1.22.0/.github/workflows/python-package.yml#L87-L92). It is harmless if you choose to not use it, but I would suggest to keep that file in.